### PR TITLE
munin/map.jinja: move lookup data to munin:. namespace

### DIFF
--- a/munin/map.jinja
+++ b/munin/map.jinja
@@ -16,7 +16,7 @@
         'cron_service': '/etc/systemd/system/munin-cron.service',
         'cron_timer': '/etc/systemd/system/munin-cron.timer',
     },
-}, merge=salt['pillar.get']('munin_master:lookup')) %}
+}, merge=salt['pillar.get']('munin:lookup:master')) %}
 
 {% set munin_node = salt['grains.filter_by']({
     'Debian': {
@@ -40,7 +40,7 @@
         'config_src': 'salt://munin/files/munin-node.conf',
         'plugin_dir': '/usr/lib/munin/plugins',
     },
-}, merge=salt['pillar.get']('munin_node:lookup')) %}
+}, merge=salt['pillar.get']('munin:lookup:node')) %}
 
 {% set net_ssleay = salt['grains.filter_by']({
     'Debian': {
@@ -62,4 +62,4 @@
         'certificate': '/etc/munin/tls/crt.pem',
         'ca_certificate': '/etc/munin/tls/cacert.pem',
     },
-}, merge=salt['pillar.get']('munin_tls:lookup')) %}
+}, merge=salt['pillar.get']('munin:lookup:tls')) %}

--- a/pillar.example
+++ b/pillar.example
@@ -1,3 +1,13 @@
+# Only enable and change or add lookup data when you need to change the defaults!
+#munin:
+#  lookup:
+#    master:
+#      config_src: 'salt://munin/files/my-munin.conf',
+#    node:
+#      config_src: 'salt://munin/files/my-munin-node.conf',
+#    tls:
+#      private_key: '/etc/ssl/private/munin/key.pem'
+
 munin_master:
   globals:
     dbdir: "/var/lib/munin"


### PR DESCRIPTION
lookupup data has been in same namespace as the config data
which caused lokkup data ended up in the munin config files

To not clutter templates with ugly "if not lookup" statements
lookup data has been moved to a global "munin:" pillar namespace