### PR TITLE
Fix typo in pillar.example

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -20,7 +20,7 @@ munin_master:
       address: "127.0.0.1"
       use_node_name: "no"
   # In case you need additional variables
-  formula_append |
+  formula_append: |
     some_variable value
 
 munin_node:


### PR DESCRIPTION
Saw this error just after it was merged into master, sorry.